### PR TITLE
[BUGFIX] Avoid usage of deprecated `TYPO3_MODE` constant

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,5 +1,6 @@
 <?php
-defined('TYPO3_MODE') or die();
+
+defined('TYPO3') or die();
 
 call_user_func(function () {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,5 +1,6 @@
 <?php
-defined('TYPO3_MODE') or die();
+
+defined('TYPO3') or die();
 
 \TRITUM\RepeatableFormElements\Configuration\Extension::addTypoScriptSetup();
 \TRITUM\RepeatableFormElements\Configuration\Extension::registerIcons();


### PR DESCRIPTION
The `TYPO3_MODE` constant was deprecated with TYPO3 v11.0. Instead, a new `TYPO3` constant was introduced.

See TYPO3/typo3@cc85324 and TYPO3/typo3@aa4bd8a for references.