### PR TITLE
[BUGFIX] Configure `allow-plugins` in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,11 @@
         "psr-4": {
             "TRITUM\\RepeatableFormElements\\": "Classes/"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "typo3/class-alias-loader": true,
+            "typo3/cms-composer-installers": true
+        }
     }
 }


### PR DESCRIPTION
The `allow-plugins` configuration is required since Composer v2.2. Without this configuration, dependencies cannot be installed properly for development.