### PR TITLE
Fix Undefined array key in CopyService

### DIFF
--- a/Classes/Service/CopyService.php
+++ b/Classes/Service/CopyService.php
@@ -296,7 +296,7 @@ class CopyService
                 $renderingOptions = $formElement->getRenderingOptions();
                 if (
                     $formElement instanceof RepeatableContainerInterface
-                    && $renderingOptions['_originalIdentifier'] === $originalIdentifier
+                    && ($renderingOptions['_originalIdentifier'] ?? null) === $originalIdentifier
                     && (bool)$renderingOptions['_isRootRepeatableContainer'] === true
                 ) {
                     $this->repeatableContainersByOriginalIdentifier[$originalIdentifier] = $formElement;


### PR DESCRIPTION
Fix an error reported by PHP 8.0+ for undefined array key in CopyService.php
An issue was already open for it here: https://github.com/tritum/repeatable_form_elements/issues/28