### PR TITLE
[BUGFIX] Register ProcessingRule of repeatable Field including DataType

### DIFF
--- a/Classes/Service/CopyService.php
+++ b/Classes/Service/CopyService.php
@@ -104,7 +104,7 @@ class CopyService
 
         if ($typo3Version->getVersion() >= 11) {
             GeneralUtility::addInstance(PropertyMappingConfiguration::class, $originalProcessingRule->getPropertyMappingConfiguration());
-            $newProcessingRule = GeneralUtility::makeInstance(ProcessingRule::class);
+            $newProcessingRule = $this->formRuntime->getFormDefinition()->getProcessingRule($newElementCopy);
         } else {
             $newProcessingRule = $this->formRuntime->getFormDefinition()->getProcessingRule($newElementCopy);
             $newProcessingRule->injectPropertyMappingConfiguration($originalProcessingRule->getPropertyMappingConfiguration());


### PR DESCRIPTION
As #31 and #32 I also had problems with image uploads after updating to extension version 3. I looked around for a while and found that the creation of the copied ProcessingRule for Typo3 11 does not work as intended. 

This small change immediateley attaches the ProcessingRule to the FormDefinition, which is not the case when using `GeneralUtility::makeInstance(ProcessingRule::class)`.

---
**Some more elaboration**

The two file upload fields of ext-form use a [check in the ProcessingRule class](https://github.com/TYPO3/typo3/blob/3c00037f2c8202da39843a93525a50e1ffb89c06/typo3/sysext/form/Classes/Mvc/ProcessingRule.php#L151)
```php
if ($this->dataType !== null) {
```
To do the actual data processing. If dataType is `null` at this point, the file uploads are not handled by the `UploadedFileReferenceConverter`.

Because of the use of `GeneralUtility::makeInstance(ProcessingRule::class)` it seems that in the CopyService the ProcessingRule gets created and the dataType field is set accordingly. But this ProcessingRule is seperate from any FormDefinition, so when the `afterBuildingFinished` hook is called a little later

https://github.com/tritum/repeatable_form_elements/blob/4394b7783402471979fe2d04716131dc3fca0752/Classes/Hooks/FormHooks.php#L121-L126

the PropertyMappingConfiguration, which has a hook registered to add the needed TypeConverters, tries to access the newly copied ProcessingRule.
```php
$propertyMappingConfiguration = $renderable->getRootForm()
    ->getProcessingRule($renderable->getIdentifier())
    ->getPropertyMappingConfiguration()
    ->setTypeConverter($typeConverter);
```

Because the ProcessingRule is not attached to the FormDefinition the code for `getProcessingRule` simply creates a new one which does not have the DataType set.

```php
public function getProcessingRule(string $propertyPath): ProcessingRule
{
    if (!isset($this->processingRules[$propertyPath])) {
        $this->processingRules[$propertyPath] = GeneralUtility::makeInstance(ProcessingRule::class);
    }
    return $this->processingRules[$propertyPath];
}
```

By using this function ourselves to create our copied ProcessingRule instance, it is immediatly added to the FormDefinition for later retrival and also results in the `FinisherContext::getFormValues` call to return `FileReference` instances. 

Fixes #31
Fixes #32 