### PR TITLE
Remove usage of jQuery

### DIFF
--- a/Resources/Private/Frontend/Partials/RepeatableContainer.html
+++ b/Resources/Private/Frontend/Partials/RepeatableContainer.html
@@ -12,7 +12,7 @@
                                 </button>
                             </f:if>
                             <f:if condition="{element.properties.showRemoveButton}">
-                                <button class="btn btn-default btn-sm disabled hidden" type="button" title="{formvh:translateElementProperty(element: element, property: 'removeButtonLabel')}" data-repeatable-container data-remove-button data-remove-button-for="{element.identifier}">
+                                <button class="btn btn-default btn-sm" type="button" title="{formvh:translateElementProperty(element: element, property: 'removeButtonLabel')}" data-repeatable-container data-remove-button data-remove-button-for="{element.identifier}" disabled>
                                     {formvh:translateElementProperty(element: element, property: 'removeButtonLabel')} <span class="glyphicon glyphicon-minus" aria-hidden="true"></span>
                                 </button>
                             </f:if>


### PR DESCRIPTION
I created a version of the RepeatableContainer.js that does not require jQuery. I also did some minor changes to the form element partial:

- 'hidden' is a Bootstrap 3 class and not really needed
- 'disabled' class is not needed - I use the attribute of the same name