### PR TITLE
Remove usage of jQuery

### DIFF
--- a/Resources/Private/Frontend/Partials/RepeatableContainer.html
+++ b/Resources/Private/Frontend/Partials/RepeatableContainer.html
@@ -12,7 +12,7 @@
                                 </button>
                             </f:if>
                             <f:if condition="{element.properties.showRemoveButton}">
-                                <button class="btn btn-default btn-sm disabled hidden" type="button" title="{formvh:translateElementProperty(element: element, property: 'removeButtonLabel')}" data-repeatable-container data-remove-button data-remove-button-for="{element.identifier}">
+                                <button class="btn btn-default btn-sm" type="button" title="{formvh:translateElementProperty(element: element, property: 'removeButtonLabel')}" data-repeatable-container data-remove-button data-remove-button-for="{element.identifier}" disabled>
                                     {formvh:translateElementProperty(element: element, property: 'removeButtonLabel')} <span class="glyphicon glyphicon-minus" aria-hidden="true"></span>
                                 </button>
                             </f:if>

--- a/Resources/Public/JavaScript/Form/Frontend/RepeatableContainer.js
+++ b/Resources/Public/JavaScript/Form/Frontend/RepeatableContainer.js
@@ -35,6 +35,11 @@ ready(() => {
         inputs.filter((input) => ['checkbox', 'radio', 'hidden'].indexOf(input.getAttribute('type')) == -1).forEach((inputElement) => {
             inputElement.setAttribute('value', '');
         });
+        inputs.filter((input) => ['file'].indexOf(input.getAttribute('type')) >= 0).forEach((inputElement) => {
+            [...inputElement.parentNode.children].filter((child) => child !== inputElement).forEach((siblingElement) => {
+                siblingElement.remove();
+            });
+        });
         inputs.filter((input) => ['checkbox', 'radio'].indexOf(input.getAttribute('type')) >= 0).forEach((inputElement) => {
             inputElement.checked = false;
         });


### PR DESCRIPTION
I created a version of the RepeatableContainer.js that does not require jQuery. I also did some minor changes to the form element partial:

- 'hidden' is a Bootstrap 3 class and not really needed
- 'disabled' class is not needed - I use the attribute of the same name

Successor to #39...