### PR TITLE
[FEATURE] Add TYPO3 v14 compatibility (drop v12)

### DIFF
--- a/.ddev/.setup/scripts/utils.sh
+++ b/.ddev/.setup/scripts/utils.sh
@@ -1,0 +1,457 @@
+#!/bin/bash
+
+# Global variable to store spinner PID
+SPINNER_PID=0
+
+# Function to display a spinner at the current cursor position (simple colored style)
+function _spinner() {
+    local chars="|/-\\"
+    local delay=0.1
+    local i=0
+    
+    while true; do
+        printf "\b\e[36m%c\e[0m" "${chars:$i:1}"
+        ((i++))
+        if [ $i -eq ${#chars} ]; then
+            i=0
+        fi
+        sleep $delay
+    done
+}
+
+function _progress() {
+    printf "%s... " "$1"
+    # Check if we're in CI environment or non-interactive terminal
+    if [[ "$VERBOSE" -eq 0 ]] && [[ -z "$CI" ]] && [[ -z "$GITHUB_ACTIONS" ]] && [[ -z "$GITLAB_CI" ]] && [[ -z "$JENKINS_URL" ]] && [[ -t 1 ]]; then
+      # Print initial space for spinner
+      printf " "
+      # Start spinner in background at current position
+      _spinner &
+      SPINNER_PID=$!
+      # Save current stdout/stderr
+      exec 3>&1 4>&2
+      exec >/dev/null 2>&1
+    else
+      printf "\n"
+    fi
+}
+
+function _done() {
+    # Stop spinner if it was started
+    if [ $SPINNER_PID -ne 0 ]; then
+      kill $SPINNER_PID 2>/dev/null
+      wait $SPINNER_PID 2>/dev/null
+      SPINNER_PID=0
+      # Restore stdout/stderr
+      exec 1>&3 2>&4
+      # Clear any remaining color codes and replace with checkmark
+      printf "\b\e[0m\e[32m✔\e[39m\n"
+    else
+      # No spinner was running, just print checkmark
+      printf "\e[32m✔\e[39m\n"
+    fi
+}
+
+
+# Function to get the lowest supported TYPO3 version from the environment variable TYPO3_VERSIONS
+# It reads the TYPO3_VERSIONS environment variable, splits it into an array, and sorts the versions.
+# If no versions are found, it prints an error message and exits with status 1.
+# Otherwise, it prints the lowest version.
+function get_lowest_supported_typo3_versions() {
+    local TYPO3_VERSIONS_ARRAY=()
+    IFS=' ' read -r -a TYPO3_VERSIONS_ARRAY <<< "$TYPO3_VERSIONS"
+    if [ ${#TYPO3_VERSIONS_ARRAY[@]} -eq 0 ]; then
+        message red "Error! No supported TYPO3 versions found in environment variables."
+        exit 1
+    fi
+    printf "%s\n" "${TYPO3_VERSIONS_ARRAY[@]}" | sort -V | head -n 1
+}
+
+# Function to get the supported TYPO3 versions from the environment variable TYPO3_VERSIONS.
+# It checks if the TYPO3_VERSIONS environment variable is set and not empty.
+# If the variable is unset or empty, it prints an error message and returns 1.
+# Otherwise, it splits the TYPO3_VERSIONS variable into an array and prints the supported versions.
+function get_supported_typo3_versions() {
+    if [ -z "${TYPO3_VERSIONS+x}" ]; then
+        message red "TYPO3_VERSIONS is unset. Please set it before running this function."
+        return 1
+    else
+        local TYPO3_VERSIONS_ARRAY=()
+        IFS=' ' read -r -a TYPO3_VERSIONS_ARRAY <<< "$TYPO3_VERSIONS"
+        if [ ${#TYPO3_VERSIONS_ARRAY[@]} -eq 0 ]; then
+            message red "Error! No supported TYPO3 versions found in environment variables."
+            return 1
+        fi
+        printf "%s\n" "${TYPO3_VERSIONS_ARRAY[@]}"
+    fi
+}
+
+# Function to check if a given TYPO3 version is supported.
+# It takes one argument, the TYPO3 version to check.
+# The function reads the supported TYPO3 versions from the environment variable TYPO3_VERSIONS.
+# If the provided version is not in the list of supported versions, it prints an error message and exits with status 1.
+# If the provided version is supported, it returns 0.
+#
+# Arguments:
+#   $1 - The TYPO3 version to check.
+#
+# Returns:
+#   0 if the provided TYPO3 version is supported.
+#   1 if the provided TYPO3 version is not supported or if no version is provided.
+function check_typo3_version() {
+    local TYPO3=$1
+    local SUPPORTED_TYPO3_VERSIONS=()
+    local found=0
+
+    if [ -z "$TYPO3" ]; then
+        message red "No TYPO3 version provided. Please set one of the supported TYPO3 versions as argument: $(get_supported_typo3_versions_comma_separated)"
+        exit 1
+    fi
+
+    while IFS= read -r line; do
+        SUPPORTED_TYPO3_VERSIONS+=("$line")
+    done < <(get_supported_typo3_versions)
+
+    for version in "${SUPPORTED_TYPO3_VERSIONS[@]}"; do
+        if [[ "$version" == "$TYPO3" ]]; then
+            found=1
+            break
+        fi
+    done
+
+    if [[ $found -eq 0 ]]; then
+        message red "TYPO3 version '$TYPO3' is not supported."
+        exit 1
+    fi
+
+    return 0
+}
+
+# Function to perform pre-setup tasks for TYPO3 installation.
+# It exports the provided TYPO3 version to the VERSION environment variable,
+# displays an introductory message for the TYPO3 version, and starts the installation process.
+#
+# Arguments:
+#   $1 - The TYPO3 version to set up.
+#
+# Usage:
+#   pre_setup <TYPO3_VERSION>
+function pre_setup() {
+  export VERSION=$1
+  message magenta "Install TYPO3 $VERSION"
+  _progress " ├─ Prepare environment"
+    export BASE_PATH="/var/www/html/.Build/$VERSION"
+    intro_typo3
+    message blue "Pre Setup for TYPO3 $VERSION"
+  _done
+  install_start
+  install_composer_packages
+}
+
+# Function to perform post-setup tasks for TYPO3 installation.
+# It changes the current directory to the base path, sets the TYPO3 installation database name,
+# and calls the appropriate post-setup function based on the TYPO3 version.
+# After that, it imports data and updates TYPO3.
+function post_setup() {
+  prepare_acceptance_testing
+
+  cd $BASE_PATH
+  TYPO3_INSTALL_DB_DBNAME=$DATABASE
+
+  _progress " ├─ Setup TYPO3"
+    if [ "$VERSION" == "11" ]; then
+      post_setup_11
+    elif [ "$VERSION" == "12" ]; then
+      post_setup_12
+    elif [ "$VERSION" == "13" ]; then
+      post_setup_13
+    elif [ "$VERSION" == "14" ]; then
+      post_setup_14
+    fi
+  _done
+
+  _progress " ├─ Import data"
+    import_xml_data
+    import_sql_data
+  _done
+  _progress " ├─ Update TYPO3"
+    update_typo3
+  _done
+  printf " └─ \033[33mTYPO3 $VERSION setup completed!\033[0m Open in your browser: https://$VERSION.${EXTENSION_NAME}.ddev.site\n"
+}
+
+# Function to display an introductory message for the TYPO3 version.
+# It prints a formatted message with the TYPO3 version in magenta color.
+function intro_typo3() {
+    message magenta "-------------------------------------------------"
+    message magenta "|\t\t\t\t\t\t|"
+    message magenta "| \t\t     TYPO3 $VERSION     \t\t|"
+    message magenta "|\t\t\t\t\t\t|"
+    message magenta "-------------------------------------------------"
+}
+
+# Function to start the installation process for TYPO3.
+# It removes any existing files in the test directory for the specified version,
+# sets up the environment, creates symlinks for the main and additional extensions,
+# and sets up Composer for the TYPO3 installation.
+function install_start() {
+    rm -rf /var/www/html/.Build/$VERSION/*
+    _progress " ├─ Setup environment"
+      setup_environment
+    _done
+    _progress " ├─ Create symlinks"
+      create_symlinks_main_extension
+      create_symlinks_additional_extensions
+    _done
+    _progress " ├─ Setup composer"
+      setup_composer
+    _done
+}
+
+# Function to set up the environment for TYPO3 installation.
+# It sets the base path for the TYPO3 installation, removes any existing files in the base path,
+# creates necessary directories, sets permissions, and exports environment variables.
+# Additionally, it drops the existing database for the TYPO3 version.
+function setup_environment() {
+    rm -rf "$BASE_PATH"
+    mkdir -p "$BASE_PATH/packages/$EXTENSION_KEY"
+    chmod 775 -R $BASE_PATH
+    export DATABASE="database_$VERSION"
+    if [ "$VERSION" == "11" ]; then
+        export TYPO3_BIN="$BASE_PATH/vendor/bin/typo3cms"
+    else
+        export TYPO3_BIN="$BASE_PATH/vendor/bin/typo3"
+    fi
+    mysql -uroot -proot -e "DROP DATABASE IF EXISTS $DATABASE"
+}
+
+# Function to create symlinks for the main extension.
+# It iterates over the items in the current directory, excluding certain directories and files,
+# and creates symbolic links for the remaining items in the specified base path.
+function create_symlinks_main_extension() {
+    local exclusions=(".*" "Documentation" "Documentation-GENERATED-temp" "var")
+    for item in ./*; do
+        local base_name=$(basename "$item")
+        for exclusion in "${exclusions[@]}"; do
+            if [[ $base_name == "$exclusion" ]]; then
+                continue 2
+            fi
+        done
+        ln -sr "$item" "$BASE_PATH/packages/$EXTENSION_KEY/$base_name"
+    done
+}
+
+# Function to create symlinks for additional extensions.
+# It iterates over the directories in the specified path and creates symbolic links
+# for each directory in the base path.
+function create_symlinks_additional_extensions() {
+    for dir in Tests/Acceptance/Fixtures/packages/*/; do
+        ln -sr "$dir" "$BASE_PATH/packages/$(basename "$dir")"
+    done
+}
+
+# Function to set up Composer for TYPO3 installation.
+# It initializes a new Composer project in the specified base path,
+# configures the TYPO3 web directory, sets up the repository for packages,
+# and allows necessary Composer plugins.
+function setup_composer() {
+    composer init --name="xima/typo3-$VERSION" --description="TYPO3 $VERSION" --no-interaction --working-dir "$BASE_PATH"
+    composer config extra.typo3/cms.web-dir public --working-dir "$BASE_PATH"
+    composer config repositories.packages path 'packages/*' --working-dir "$BASE_PATH"
+    composer config --no-interaction allow-plugins.typo3/cms-composer-installers true --working-dir "$BASE_PATH"
+    composer config --no-interaction allow-plugins.typo3/class-alias-loader true --working-dir "$BASE_PATH"
+}
+
+# Function to set up TYPO3 configuration.
+# It changes the current directory to the base path, sets the TYPO3 installation database name,
+# and configures various TYPO3 settings such as debug mode, error display, trusted hosts pattern,
+# mail transport, and graphics processor.
+function setup_typo3() {
+    cd $BASE_PATH
+    export TYPO3_INSTALL_DB_DBNAME=$DATABASE
+    $TYPO3_BIN configuration:set 'BE/debug' 1
+    $TYPO3_BIN configuration:set 'FE/debug' 1
+    $TYPO3_BIN configuration:set 'SYS/devIPmask' '*'
+    $TYPO3_BIN configuration:set 'SYS/displayErrors' 1
+    $TYPO3_BIN configuration:set 'SYS/trustedHostsPattern' '.*.*'
+    $TYPO3_BIN configuration:set 'MAIL/transport' 'smtp'
+    $TYPO3_BIN configuration:set 'MAIL/transport_smtp_server' 'localhost:1025'
+    $TYPO3_BIN configuration:set 'GFX/processor' 'ImageMagick'
+    $TYPO3_BIN configuration:set 'GFX/processor_path' '/usr/bin/'
+}
+
+# Function to update TYPO3.
+# It updates the TYPO3 database schema and flushes the cache.
+function update_typo3() {
+    $TYPO3_BIN database:updateschema
+    $TYPO3_BIN cache:flush
+}
+
+# Function to install required Composer packages for TYPO3.
+function install_composer_packages() {
+  _progress " ├─ Install composer packages"
+    composer req typo3/cms-base-distribution:"^$VERSION" \
+            $PACKAGE_NAME:'*@dev' \
+            test/sitepackage:'*@dev' \
+            helhum/typo3-console:'*' \
+            --no-progress -n -d $BASE_PATH
+  _done
+}
+
+# Function to install Codeception and related packages using Composer.
+# It checks if the codeception.yml file exists in the extension's package directory.
+# If the file exists, it installs the necessary Codeception packages, creates symlinks for
+# the codeception.yml file and acceptance tests directory, and builds the Codeception configuration.
+function prepare_acceptance_testing() {
+  if [ ! -f "$BASE_PATH/packages/$EXTENSION_KEY/codeception.yml" ]; then
+      return
+  fi
+  _progress " ├─ Prepare acceptance testing"
+    composer config --no-interaction allow-plugins.codeception/c3 true --working-dir "$BASE_PATH"
+    composer req --dev codeception/codeception:'*' \
+              codeception/module-asserts:'*' \
+              codeception/module-cli:'*' \
+              codeception/module-db:'*' \
+              codeception/module-phpbrowser:'*' \
+              codeception/module-webdriver:'*' \
+              eliashaeussler/typo3-codeception-helper:'*' \
+              typo3/testing-framework:'*' \
+              --no-progress -n -d $BASE_PATH
+
+    ln -sr "$BASE_PATH/packages/$EXTENSION_KEY/codeception.yml" "$BASE_PATH/codeception.yml"
+    mkdir -p "$BASE_PATH/Tests"
+    ln -sr "$BASE_PATH/packages/$EXTENSION_KEY/Tests/Acceptance" "$BASE_PATH/Tests/Acceptance"
+
+    $BASE_PATH/vendor/bin/codecept build -c $BASE_PATH/codeception.yml
+  _done
+}
+
+# Function to import XML data into TYPO3.
+# It sets the public directory and export directory paths, checks for all .xml files in the FIXTURE_DIR,
+# and imports each XML file using TYPO3's import/export tool.
+function import_xml_data() {
+    PUBLIC_DIR="/var/www/html/.Build/${VERSION}/public"
+    EXPORT_DIR="${PUBLIC_DIR}/fileadmin/user_upload/_temp_/importexport"
+    FIXTURE_DIR="/var/www/html/Tests/Acceptance/Fixtures"
+
+    mkdir -p $EXPORT_DIR
+
+    for XML_FILE in "$FIXTURE_DIR"/*.xml; do
+        if [ -f "$XML_FILE" ]; then
+            FILENAME=$(basename "$XML_FILE")
+            message yellow "Importing XML file $FILENAME..."
+            cp "$XML_FILE" "$EXPORT_DIR/"
+            $TYPO3_BIN impexp:import -vvv --force-uid "$EXPORT_DIR/$FILENAME"
+        fi
+    done
+
+    # Check if no XML files were found
+    if ! ls "$FIXTURE_DIR"/*.xml >/dev/null 2>&1; then
+        message yellow "No XML files found in $FIXTURE_DIR. Skipping XML import."
+    fi
+}
+
+# Function to import SQL data into TYPO3.
+# It checks if the SQL data files exists, and if it does, it imports the SQL
+# data into the TYPO3 database using the MySQL command.
+function import_sql_data() {
+    FIXTURE_DIR="/var/www/html/Tests/Acceptance/Fixtures"
+
+    for DATA_FILE in "$FIXTURE_DIR"/*.sql; do
+        if [ -f "$DATA_FILE" ]; then
+            message yellow "Importing $DATA_FILE..."
+            mysql -h db -u root -p"root" $DATABASE < "$DATA_FILE"
+        else
+          message yellow "No SQL files found in $FIXTURE_DIR. Import will be skipped."
+        fi
+    done
+}
+
+# Function to perform post-setup tasks for TYPO3 version 11.
+# It sets up TYPO3 by running the installation setup, configuring TYPO3 settings,
+# and modifying configuration files to enable deprecations and adjust base paths.
+function post_setup_11 {
+  $TYPO3_BIN install:setup -n --database-name $DATABASE
+  setup_typo3
+  $TYPO3_BIN configuration:set 'GFX/processor_path_lzw' '/usr/bin/'
+
+  sed -i "/'deprecations'/,/^[[:space:]]*'disabled' => true,/s/'disabled' => true,/'disabled' => false,/" /var/www/html/.Build/$VERSION/public/typo3conf/LocalConfiguration.php
+
+  sed -i -e "s/base: ht\//base: \//g" /var/www/html/.Build/$VERSION/config/sites/main/config.yaml
+  sed -i -e 's/base: \/en\//base: \//g' /var/www/html/.Build/$VERSION/config/sites/main/config.yaml
+}
+
+# Function to perform post-setup tasks for TYPO3 version 12.
+# It sets up TYPO3 by running the installation setup, configuring TYPO3 settings,
+# and modifying configuration files to enable deprecations and adjust base paths.
+function post_setup_12 {
+  $TYPO3_BIN install:setup -n --database-name $DATABASE
+  setup_typo3
+
+  sed -i "/'deprecations'/,/^[[:space:]]*'disabled' => true,/s/'disabled' => true,/'disabled' => false,/" /var/www/html/.Build/$VERSION/config/system/settings.php
+
+  sed -i -e "s/base: ht\//base: \//g" /var/www/html/.Build/$VERSION/config/sites/main/config.yaml
+  sed -i -e 's/base: \/en\//base: \//g' /var/www/html/.Build/$VERSION/config/sites/main/config.yaml
+}
+
+# Function to perform post-setup tasks for TYPO3 version 13.
+# It creates the TYPO3 database, sets up TYPO3 by running the installation setup,
+# configures TYPO3 settings, and modifies configuration files to enable deprecations.
+function post_setup_13 {
+  mysql -h db -u root -p"root" -e "CREATE DATABASE $DATABASE;"
+  $TYPO3_BIN  setup -n --dbname=$DATABASE --password=$TYPO3_DB_PASSWORD --create-site="https://${VERSION}.${EXTENSION_NAME}.ddev.site" --admin-user-password=$TYPO3_SETUP_ADMIN_PASSWORD
+  setup_typo3
+
+  sed -i "/'deprecations'/,/^[[:space:]]*'disabled' => true,/s/'disabled' => true,/'disabled' => false,/" /var/www/html/.Build/$VERSION/config/system/settings.php
+}
+
+# Function to perform post-setup tasks for TYPO3 version 14.
+# It creates the TYPO3 database, sets up TYPO3 by running the installation setup,
+# configures TYPO3 settings, and modifies configuration files to enable deprecations.
+function post_setup_14 {
+  mysql -h db -u root -p"root" -e "CREATE DATABASE $DATABASE;"
+  $TYPO3_BIN  setup -n --dbname=$DATABASE --password=$TYPO3_DB_PASSWORD --create-site="https://${VERSION}.${EXTENSION_NAME}.ddev.site" --admin-user-password=$TYPO3_SETUP_ADMIN_PASSWORD
+  setup_typo3
+
+  sed -i "/'deprecations'/,/^[[:space:]]*'disabled' => true,/s/'disabled' => true,/'disabled' => false,/" /var/www/html/.Build/$VERSION/config/system/settings.php
+}
+
+# Function to display a colored message.
+# It takes two arguments: the color and the message to display.
+# The function supports the following colors: red, green, yellow, blue, magenta, cyan.
+# If an unsupported color is provided, the message is displayed without color.
+#
+# Usage:
+#   message <color> <message>
+#
+# Arguments:
+#   color   - The color to use for the message (red, green, yellow, blue, magenta, cyan).
+#   message - The message to display.
+message() {
+    local color=$1
+    local message=$2
+
+    case $color in
+        red)
+            echo -e "\033[31m$message\033[0m"
+            ;;
+        green)
+            echo -e "\033[32m$message\033[0m"
+            ;;
+        yellow)
+            echo -e "\033[33m$message\033[0m"
+            ;;
+        blue)
+            echo -e "\033[34m$message\033[0m"
+            ;;
+        magenta)
+            echo -e "\033[35m$message\033[0m"
+            ;;
+        cyan)
+            echo -e "\033[36m$message\033[0m"
+            ;;
+        *)
+            echo -e "$message"
+            ;;
+    esac
+}

--- a/.ddev/.setup/templates/index.php
+++ b/.ddev/.setup/templates/index.php
@@ -1,0 +1,102 @@
+<?php
+$extensionKey = getenv('EXTENSION_NAME');
+$typo3AdminUser = getenv('TYPO3_SETUP_ADMIN_USERNAME');
+$typo3AdminPassword = getenv('TYPO3_SETUP_ADMIN_PASSWORD');
+$supportedVersions = explode(' ', getenv('TYPO3_VERSIONS'));
+
+// Check if composer.json exists
+$composerJsonPath = __DIR__ . '/../composer.json';
+if (file_exists($composerJsonPath)) {
+    $composerJsonContent = file_get_contents($composerJsonPath);
+    $composerData = json_decode($composerJsonContent, true);
+    $description = $composerData['description'];
+} else {
+    $description = 'composer.json file not found. =(';
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title><?php echo $extensionKey; ?></title>
+    <link
+            rel="stylesheet"
+            href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"
+    >
+    <style>
+        .flex {
+            display: flex;
+            gap: 10px;
+        }
+    </style>
+</head>
+<body>
+<header class="container">
+    <h1>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="-0.5 -0.5 24 24" id="Typo3-Icon--Streamline-Svg-Logos.svg" height="40" width="40"><path fill="#F49700" d="M9.895582291666667 0.5915863541666667c-0.4094479166666667 0.35015104166666666 -0.7003020833333333 0.7595869791666667 -0.7003020833333333 1.9823292708333333 0 3.32738125 4.19994375 13.322414583333334 7.060448958333334 13.322414583333334 0.32128125 0.004360416666666667 0.6412927083333333 -0.04125625 0.9485583333333334 -0.13522083333333335l-0.0060375 0.0016770833333333334 -0.07309687499999999 0.11725208333333334C14.656414583333333 19.815003125000004 11.685221875 22.70162291666667 9.887244791666667 22.759530208333334L9.832571875000001 22.760416666666668C5.927195833333333 22.760416666666668 0.38405927083333335 10.970137500000002 0.38405927083333335 5.7827270833333335c0 -0.8170270833333334 0.185265 -1.45805625 0.46686645833333335 -1.8563635416666668C2.194099375 2.2849110416666667 6.394071875000001 0.9991703125 9.895582291666667 0.5915863541666667ZM15.379429166666668 0.23958333333333334c3.616366666666667 0 7.236446875 0.5835842708333334 7.236446875 2.6252104166666665 0 4.142515625000001 -2.627055208333333 9.1632 -3.9683864583333337 9.1632 -2.391760416666667 0 -5.372680208333334 -6.652869791666666 -5.372680208333334 -9.980222291666667C13.274809375 0.5304494791666666 13.856541666666667 0.23958333333333334 15.373870833333335 0.23958333333333334h0.0055583333333333335Z" stroke-width="1"></path></svg>
+        <?php echo $extensionKey; ?></h1>
+</header>
+<main class="container">
+    <blockquote><?php echo $description; ?></blockquote>
+    <hr/>
+    <p>Run <code>ddev install all</code> to install all TYPO3 instances below:</p>
+    <?php
+    foreach ($supportedVersions as $version) {
+        $directoryPath = '/var/www/html/.Build/' . $version;
+        if (is_dir($directoryPath)) {
+            echo "<article class='flex'><kbd>{$version}</kbd><div><strong>Frontend</strong><br/><strong>Backend</strong></div><div><a target='_blank' href='https://{$version}.{$extensionKey}.ddev.site'>https://{$version}.{$extensionKey}.ddev.site</a><br/><a target='_blank' href='https://{$version}.{$extensionKey}.ddev.site/typo3/?u={$typo3AdminUser}&p={$typo3AdminPassword}'>https://{$version}.{$extensionKey}.ddev.site/typo3</a></div></article>";
+        } else {
+            echo "<article>Version {$version} is not installed. Run <code>ddev install {$version}</code> to install.</article>";
+        }
+    }
+?>
+    <h2>Additional information</h2>
+    <h4>DDEV commands</h4>
+    <?php
+// Directories to scan for DDEV commands
+$directories = [
+    '/var/www/html/.ddev/commands/web',
+    '/var/www/html/.ddev/commands/host',
+];
+
+foreach ($directories as $directory) {
+    foreach (new DirectoryIterator($directory) as $fileInfo) {
+        $filePath = $fileInfo->getPathname();
+        $fileName = $fileInfo->getFilename();
+
+        if ($fileName[0] === '.' || $fileInfo->isDir()) {
+            continue;
+        }
+
+        $fileContent = file($filePath);
+        if (str_starts_with($fileContent[0], '#!/bin/bash')) {
+            $description = '';
+            $usage = '';
+            $example = '';
+
+            foreach ($fileContent as $line) {
+                if (str_starts_with($line, '## Description:')) {
+                    $description = trim(str_replace('## Description:', '', $line));
+                } elseif (str_starts_with($line, '## Usage:')) {
+                    $usage = trim(str_replace('## Usage:', '', $line));
+                } elseif (str_starts_with($line, '## Example:')) {
+                    $example = trim(str_replace('## Example:', '', $line));
+                }
+            }
+
+            echo "<article><code>ddev $usage</code><br/>$description<br/> <em>Example: $example</em></article>";
+        }
+    }
+}
+?>
+    <details open>
+        <summary><h4>TYPO3 Backend Credentials</h4></summary>
+        <ul>
+            <li>Username: <code><?php echo $typo3AdminUser; ?></code></li>
+            <li>Password: <code><?php echo $typo3AdminPassword; ?></code></li>
+        </ul>
+    </details>
+</main>
+
+</body>
+</html>

--- a/.ddev/addon-metadata/typo3-multi-version-extension/manifest.yaml
+++ b/.ddev/addon-metadata/typo3-multi-version-extension/manifest.yaml
@@ -1,0 +1,26 @@
+name: typo3-multi-version-extension
+repository: konradmichalik/ddev-typo3-multi-version-extension
+version: 0.3.0
+install_date: "2026-04-20T14:42:24+02:00"
+project_files:
+    - .setup/scripts/utils.sh
+    - .setup/templates/index.php
+    - .setup/Tests/Acceptance/Fixtures/
+    - apache/10.conf
+    - apache/20.conf
+    - commands/host/launch
+    - commands/web/.install-11
+    - commands/web/.install-12
+    - commands/web/.install-13
+    - commands/web/.install-14
+    - commands/web/11
+    - commands/web/12
+    - commands/web/13
+    - commands/web/14
+    - commands/web/all
+    - commands/web/install
+    - docker-compose.typo3-setup.yaml
+global_files: []
+removal_actions:
+    - rm ${DDEV_APPROOT}/.ddev/config.typo3-setup.yaml
+    - rm -f ${DDEV_APPROOT}/.ddev/.setup/

--- a/.ddev/apache/10.conf
+++ b/.ddev/apache/10.conf
@@ -1,0 +1,43 @@
+#ddev-generated
+# If you want to take over this file and customize it, remove the line above
+# and ddev will respect it and won't overwrite the file.
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#custom-apache-configuration
+<VirtualHost *:80>
+    ServerName repeatable-form-elements.ddev.site
+    DocumentRoot /var/www/html/.Build
+    <Directory "/var/www/html/.Build">
+  		AllowOverride All
+  		Allow from All
+	</Directory>
+
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName repeatable-form-elements.ddev.site
+    DocumentRoot /var/www/html/.Build
+    <Directory "/var/www/html/.Build">
+  		AllowOverride All
+  		Allow from All
+	</Directory>
+
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/master.crt
+    SSLCertificateKeyFile /etc/ssl/certs/master.key
+</VirtualHost>

--- a/.ddev/apache/20.conf
+++ b/.ddev/apache/20.conf
@@ -1,0 +1,51 @@
+#ddev-generated
+# If you want to take over this file and customize it, remove the line above
+# and ddev will respect it and won't overwrite the file.
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#custom-apache-configuration
+<VirtualHost *:80>
+    ServerName sub.repeatable-form-elements.ddev.site
+    ServerAlias *.repeatable-form-elements.ddev.site
+    DocumentRoot /var/www/html/.Build
+    <Directory "/var/www/html/.Build">
+  		AllowOverride All
+  		Allow from All
+	</Directory>
+
+    RewriteEngine On
+    RewriteCond %{HTTP_HOST} ^([a-z0-9-]+)\.repeatable-form-elements\.ddev\.site$
+    RewriteRule ^(.*)$ /var/www/html/.Build/%1/public/$1 [L]
+
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName sub.repeatable-form-elements.ddev.site
+    ServerAlias *.repeatable-form-elements.ddev.site
+    DocumentRoot /var/www/html/.Build
+    <Directory "/var/www/html/.Build">
+  		AllowOverride All
+  		Allow from All
+	</Directory>
+
+    RewriteEngine On
+    RewriteCond %{HTTP_HOST} ^([a-z0-9-]+)\.repeatable-form-elements\.ddev\.site$
+    RewriteRule ^(.*)$ /var/www/html/.Build/%1/public/$1 [L]
+
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/master.crt
+    SSLCertificateKeyFile /etc/ssl/certs/master.key
+</VirtualHost>

--- a/.ddev/commands/web/.install-11
+++ b/.ddev/commands/web/.install-11
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+## #ddev-generated
+. .ddev/.setup/scripts/utils.sh
+
+# Pre-setup function for TYPO3 version 11.
+# This function is part of the installation script and is responsible for performing
+# initial setup tasks before the main installation process begins.
+pre_setup 11
+
+#_progress " ├─ Install additional composer packages"
+#  composer req x/y:'^1.0' \
+#          --no-progress -n -d $BASE_PATH
+#_done
+
+# Function to perform post-setup tasks.
+# This function is called after the main installation process to finalize the setup.
+# It typically includes tasks such as configuring settings, modifying files, and other necessary adjustments.
+post_setup

--- a/.ddev/commands/web/.install-12
+++ b/.ddev/commands/web/.install-12
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+. .ddev/.setup/scripts/utils.sh
+
+# Pre-setup function for TYPO3 version 12.
+# This function is part of the installation script and is responsible for performing
+# initial setup tasks before the main installation process begins.
+pre_setup 12
+
+#_progress " ├─ Install additional composer packages"
+#  composer req x/y:'^1.0' \
+#          --no-progress -n -d $BASE_PATH
+#_done
+
+# Function to perform post-setup tasks.
+# This function is called after the main installation process to finalize the setup.
+# It typically includes tasks such as configuring settings, modifying files, and other necessary adjustments.
+post_setup

--- a/.ddev/commands/web/.install-13
+++ b/.ddev/commands/web/.install-13
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+. .ddev/.setup/scripts/utils.sh
+
+# Pre-setup function for TYPO3 version 13.
+pre_setup 13
+
+# Copy form definitions to fileadmin (before post_setup so they exist when TYPO3 boots)
+_progress " ├─ Copy form definitions"
+  FORM_DIR="$BASE_PATH/public/fileadmin/form_definitions"
+  mkdir -p "$FORM_DIR"
+  cp /var/www/html/Tests/Acceptance/Fixtures/form_definitions/*.form.yaml "$FORM_DIR/" 2>/dev/null || true
+_done
+
+post_setup
+
+# v13 needs sys_template with explicit TypoScript imports + PAGE definition
+_progress " ├─ Configure sys_template"
+  cd $BASE_PATH
+  php -r '
+  $pdo = new PDO("mysql:host=db;dbname='$DATABASE'", "root", "root");
+  $config = "@import \"EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript\"\n@import \"EXT:form/Configuration/TypoScript/setup.typoscript\"\n@import \"EXT:repeatable_form_elements/Configuration/TypoScript/setup.typoscript\"\n\npage = PAGE\npage.typeNum = 0\npage.includeCSSLibs.bootstrap = https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css\npage.includeCSSLibs.bootstrap.external = 1\npage.10 = FLUIDTEMPLATE\npage.10.templateName = Default\npage.10.templateRootPaths.10 = EXT:sitepackage/Resources/Private/Templates/Page/\npage.10.layoutRootPaths.10 = EXT:sitepackage/Resources/Private/Layouts/\n";
+  $pdo->prepare("UPDATE sys_template SET config = ? WHERE pid = 1")->execute([$config]);
+  echo "sys_template updated\n";
+  '
+_done
+
+# Add site set dependency AFTER post_setup (site config is created during post_setup)
+_progress " ├─ Configure site set"
+  SITE_CONFIG="$BASE_PATH/config/sites/main/config.yaml"
+  if [ -f "$SITE_CONFIG" ]; then
+    cd $BASE_PATH
+    php -r '
+    $f = "config/sites/main/config.yaml";
+    $c = file_get_contents($f);
+    $c = preg_replace("/^dependencies:\n(  - .*\n)*/m", "dependencies:\n  - test/sitepackage\n", $c);
+    file_put_contents($f, $c);
+    '
+  fi
+_done
+
+_progress " ├─ Flush cache"
+  $TYPO3_BIN cache:flush
+_done

--- a/.ddev/commands/web/.install-14
+++ b/.ddev/commands/web/.install-14
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+. .ddev/.setup/scripts/utils.sh
+
+# Pre-setup function for TYPO3 version 14.
+pre_setup 14
+
+# Copy form definitions to fileadmin (before post_setup so they exist when TYPO3 boots)
+_progress " ├─ Copy form definitions"
+  FORM_DIR="$BASE_PATH/public/fileadmin/form_definitions"
+  mkdir -p "$FORM_DIR"
+  cp /var/www/html/Tests/Acceptance/Fixtures/form_definitions/*.form.yaml "$FORM_DIR/" 2>/dev/null || true
+_done
+
+post_setup
+
+# v14: Remove sys_template to avoid double rendering (site sets provide all TypoScript)
+_progress " ├─ Remove sys_template"
+  cd $BASE_PATH
+  php -r '
+  $pdo = new PDO("mysql:host=db;dbname='$DATABASE'", "root", "root");
+  $pdo->exec("DELETE FROM sys_template");
+  echo "sys_template removed\n";
+  '
+_done
+
+# v14: Disable contentRenderingTemplates to prevent double content rendering
+_progress " ├─ Disable contentRenderingTemplates"
+  echo '<?php $GLOBALS["TYPO3_CONF_VARS"]["FE"]["contentRenderingTemplates"] = [];' > $BASE_PATH/config/system/additional.php
+_done
+
+# Add test/sitepackage to existing site dependencies
+_progress " ├─ Configure site set"
+  SITE_CONFIG="$BASE_PATH/config/sites/main/config.yaml"
+  if [ -f "$SITE_CONFIG" ]; then
+    cd $BASE_PATH
+    php -r '
+    $f = "config/sites/main/config.yaml";
+    $c = file_get_contents($f);
+    if (strpos($c, "test/sitepackage") === false) {
+      $c = preg_replace("/^(dependencies:\n(?:  - .*\n)*)/m", "$1  - test/sitepackage\n", $c);
+      file_put_contents($f, $c);
+    }
+    '
+  fi
+_done
+
+_progress " ├─ Flush cache"
+  rm -rf $BASE_PATH/var/cache/*
+  $TYPO3_BIN cache:flush
+_done

--- a/.ddev/commands/web/11
+++ b/.ddev/commands/web/11
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Exec command for TYPO3 instance 11.
+## Usage: 11
+## Example: "ddev 11 composer du -o" or "ddev 11 typo3 cache:flush"
+
+. .ddev/.setup/scripts/utils.sh
+
+command=$@
+version=11
+
+if [[ $command == typo3* ]]; then
+    command="/usr/bin/php vendor/bin/typo3cms${command:5}"
+fi
+
+TYPO3_PATH=".Build/${version}"
+if [ -d "$TYPO3_PATH" ]; then
+    message magenta "[TYPO3 v${version}] ${command}"
+    cd $TYPO3_PATH
+    $command
+else
+    message red "TYPO3 binary not found for version ${version}"
+fi

--- a/.ddev/commands/web/12
+++ b/.ddev/commands/web/12
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+## Description: Exec command for TYPO3 instance 12.
+## Usage: 12
+## Example: "ddev 12 composer du -o" or "ddev 12 typo3 cache:flush"
+
+. .ddev/.setup/scripts/utils.sh
+
+command=$@
+version=12
+
+if [[ $command == typo3* ]]; then
+    command="/usr/bin/php vendor/bin/${command}"
+fi
+
+TYPO3_PATH=".Build/${version}"
+if [ -d "$TYPO3_PATH" ]; then
+    message magenta "[TYPO3 v${version}] ${command}"
+    cd $TYPO3_PATH
+    $command
+else
+    message red "TYPO3 binary not found for version ${version}"
+fi

--- a/.ddev/commands/web/13
+++ b/.ddev/commands/web/13
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+## Description: Exec command for TYPO3 instance 13.
+## Usage: 13
+## Example: "ddev 13 composer du -o" or "ddev 13 typo3 cache:flush"
+
+. .ddev/.setup/scripts/utils.sh
+
+command=$@
+version=13
+
+if [[ $command == typo3* ]]; then
+    command="/usr/bin/php vendor/bin/${command}"
+fi
+
+TYPO3_PATH=".Build/${version}"
+if [ -d "$TYPO3_PATH" ]; then
+    message magenta "[TYPO3 v${version}] ${command}"
+    cd $TYPO3_PATH
+    $command
+else
+    message red "TYPO3 binary not found for version ${version}"
+fi

--- a/.ddev/commands/web/14
+++ b/.ddev/commands/web/14
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+## Description: Exec command for TYPO3 instance 14.
+## Usage: 14
+## Example: "ddev 14 composer du -o" or "ddev 14 typo3 cache:flush"
+
+. .ddev/.setup/scripts/utils.sh
+
+command=$@
+version=14
+
+if [[ $command == typo3* ]]; then
+    command="/usr/bin/php vendor/bin/${command}"
+fi
+
+TYPO3_PATH=".Build/${version}"
+if [ -d "$TYPO3_PATH" ]; then
+    message magenta "[TYPO3 v${version}] ${command}"
+    cd $TYPO3_PATH
+    $command
+else
+    message red "TYPO3 binary not found for version ${version}"
+fi

--- a/.ddev/commands/web/all
+++ b/.ddev/commands/web/all
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+## Description: Exec command for all TYPO3 instances.
+## Usage: all
+## Example: "ddev all composer du -o" or "ddev all typo3 cache:flush"
+
+. .ddev/.setup/scripts/utils.sh
+
+command=$@
+mapfile -t versions < <(get_supported_typo3_versions)
+
+for version in "${versions[@]}"; do
+    TYPO3_PATH="/var/www/html/.Build/${version}"
+    if [ -d "$TYPO3_PATH" ]; then
+        if [[ $command == typo3* ]]; then
+            if [[ $version == 11 ]]; then
+                tempCommand="/usr/bin/php vendor/bin/typo3cms${command:5}"
+            else
+                tempCommand="/usr/bin/php vendor/bin/${command}"
+            fi
+        fi
+        cd $TYPO3_PATH
+        message magenta "[TYPO3 v${version}] ${tempCommand}"
+        $tempCommand
+    else
+        message red "TYPO3 instance not found for version ${version}"
+    fi
+done

--- a/.ddev/commands/web/install
+++ b/.ddev/commands/web/install
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+## #ddev-generated
+## Description: Install TYPO3 instances.
+## Usage: install
+## Example: "ddev install" or "ddev install 12" or "ddev install all"
+## MutagenSync: true
+
+TYPO3=${1}
+
+. .ddev/.setup/scripts/utils.sh
+
+if [ "$TYPO3" == "all" ]; then
+    mapfile -t versions < <(get_supported_typo3_versions)
+    for version in "${versions[@]}"; do
+        .ddev/commands/web/.install-$version
+    done
+else
+    if [ -z "$TYPO3" ]; then
+        TYPO3=$(get_lowest_supported_typo3_versions)
+    else
+        if ! check_typo3_version "$TYPO3"; then
+            exit 1
+        fi
+    fi
+    ".ddev/commands/web/.install-$TYPO3"
+fi

--- a/.ddev/config.typo3-setup.yaml
+++ b/.ddev/config.typo3-setup.yaml
@@ -1,0 +1,11 @@
+type: php
+docroot: .Build
+webserver_type: apache-fpm
+additional_hostnames:
+  - 11.repeatable-form-elements
+  - 12.repeatable-form-elements
+  - 13.repeatable-form-elements
+  - 14.repeatable-form-elements
+hooks:
+   post-start:
+    - exec: mkdir -p /var/www/html/.Build/ && cp /var/www/html/.ddev/.setup/templates/* /var/www/html/.Build/

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,0 +1,293 @@
+name: repeatable-form-elements
+type: typo3
+docroot: ""
+php_version: "8.3"
+webserver_type: apache-fpm
+xdebug_enabled: false
+additional_hostnames: []
+additional_fqdns: []
+database:
+    type: mariadb
+    version: "11.4"
+use_dns_when_possible: true
+composer_version: "2"
+web_environment: []
+corepack_enable: false
+
+# Key features of DDEV's config.yaml:
+
+# name: <projectname> # Name of the project, automatically provides
+#   http://projectname.ddev.site and https://projectname.ddev.site
+# If the name is omitted, the project will take the name of the enclosing directory,
+# which is useful if you want to have a copy of the project side by side with this one.
+
+# type: <projecttype>  # backdrop, cakephp, codeigniter, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, drupal12, generic, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress
+# See https://docs.ddev.com/en/stable/users/quickstart/ for more
+# information on the different project types
+
+# docroot: <relative_path> # Relative path to the directory containing index.php.
+
+# php_version: "8.4"  # PHP version to use, "5.6" through "8.5"
+
+# You can explicitly specify the webimage but this
+# is not recommended, as the images are often closely tied to DDEV's' behavior,
+# so this can break upgrades.
+
+# webimage: <docker_image>
+# It’s unusual to change this option, and we don’t recommend it without Docker experience and a good reason.
+# Typically, this means additions to the existing web image using a .ddev/web-build/Dockerfile.*
+
+# database:
+#   type: <dbtype> # mysql, mariadb, postgres
+#   version: <version> # database version, like "10.11" or "8.0"
+#   MariaDB versions can be 5.5-10.8, 10.11, 11.4, 11.8
+#   MySQL versions can be 5.5-8.0, 8.4
+#   PostgreSQL versions can be 9-18
+
+# router_http_port: <port>  # Port to be used for http (defaults to global configuration, usually 80)
+# router_https_port: <port> # Port for https (defaults to global configuration, usually 443)
+
+# xdebug_enabled: false  # Set to true to enable Xdebug and "ddev start" or "ddev restart"
+# Note that for most people the commands
+# "ddev xdebug" to enable Xdebug and "ddev xdebug off" to disable it work better,
+# as leaving Xdebug enabled all the time is a big performance hit.
+
+# xhgui_http_port: "8143"
+# xhgui_https_port: "8142"
+# The XHGui ports can be changed from the default 8143 and 8142
+# Very rarely used
+
+# host_xhgui_port: "8142"
+# Can be used to change the host binding port of the XHGui
+# application. Rarely used; only when port conflict and
+# bind_all_ports is used (normally with router disabled)
+
+# xhprof_mode: [prepend|xhgui|global]
+# Default is "xhgui"
+
+# webserver_type: nginx-fpm, apache-fpm, generic
+
+# timezone: Europe/Berlin
+# If timezone is unset, DDEV will attempt to derive it from the host system timezone
+# using the $TZ environment variable or the /etc/localtime symlink.
+# This is the timezone used in the containers and by PHP;
+# it can be set to any valid timezone,
+# see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+# For example Europe/Dublin or MST7MDT
+
+# composer_root: <relative_path>
+# Relative path to the Composer root directory from the project root. This is
+# the directory which contains the composer.json and where all Composer related
+# commands are executed.
+
+# composer_version: "2"
+# You can set it to "" or "2" (default) for Composer v2
+# to use the latest major version available at the time your container is built.
+# It is also possible to use each other Composer version channel. This includes:
+#   - 2.2 (latest Composer LTS version)
+#   - stable
+#   - preview
+#   - snapshot
+# Alternatively, an explicit Composer version may be specified, for example "2.2.18".
+# To reinstall Composer after the image was built, run "ddev utility rebuild".
+
+# nodejs_version: "24"
+# change from the default system Node.js version to any other version.
+# See https://docs.ddev.com/en/stable/users/configuration/config/#nodejs_version for more information
+# and https://www.npmjs.com/package/n#specifying-nodejs-versions for the full documentation.
+
+# corepack_enable: false
+# Change to 'true' to 'corepack enable' and gain access to latest versions of yarn/pnpm
+
+# additional_hostnames:
+#  - somename
+#  - someothername
+# would provide http and https URLs for "somename.ddev.site"
+# and "someothername.ddev.site".
+
+# additional_fqdns:
+#  - example.com
+#  - sub1.example.com
+# would provide http and https URLs for "example.com" and "sub1.example.com"
+# Please take care with this because it can cause great confusion.
+
+# upload_dirs: "custom/upload/dir"
+#
+# upload_dirs:
+#   - custom/upload/dir
+#   - ../private
+#
+# would set the destination paths for ddev import-files to <docroot>/custom/upload/dir
+# When Mutagen is enabled this path is bind-mounted so that all the files
+# in the upload_dirs don't have to be synced into Mutagen.
+
+# disable_upload_dirs_warning: false
+# If true, turns off the normal warning that says
+# "You have Mutagen enabled and your 'php' project type doesn't have upload_dirs set"
+
+# ddev_version_constraint: ""
+# Example:
+# ddev_version_constraint: ">= 1.24.8"
+# This will enforce that the running ddev version is within this constraint.
+# See https://github.com/Masterminds/semver#checking-version-constraints for
+# supported constraint formats
+
+# working_dir:
+#   web: /var/www/html
+#   db: /home
+# would set the default working directory for the web and db services.
+# These values specify the destination directory for ddev ssh and the
+# directory in which commands passed into ddev exec are run.
+
+# omit_containers: [db, ddev-ssh-agent]
+# Currently only these containers are supported. Some containers can also be
+# omitted globally in the ~/.ddev/global_config.yaml. Note that if you omit
+# the "db" container, several standard features of DDEV that access the
+# database container will be unusable. In the global configuration it is also
+# possible to omit ddev-router, but not here.
+
+# performance_mode: "global"
+# DDEV offers performance optimization strategies to improve the filesystem
+# performance depending on your host system. Should be configured globally.
+#
+# If set, will override the global config. Possible values are:
+#   - "global":  uses the value from the global config.
+#   - "none":    disables performance optimization for this project.
+#   - "mutagen": enables Mutagen for this project.
+#
+# See https://docs.ddev.com/en/stable/users/install/performance/#mutagen
+
+# fail_on_hook_fail: False
+# Decide whether 'ddev start' should be interrupted by a failing hook
+
+# host_https_port: "59002"
+# The host port binding for https can be explicitly specified. It is
+# dynamic unless otherwise specified.
+# This is not used by most people, most people use the *router* instead
+# of the localhost port.
+
+# host_webserver_port: "59001"
+# The host port binding for the ddev-webserver can be explicitly specified. It is
+# dynamic unless otherwise specified.
+# This is not used by most people, most people use the *router* instead
+# of the localhost port.
+
+# host_db_port: "59002"
+# The host port binding for the ddev-dbserver can be explicitly specified. It is dynamic
+# unless explicitly specified.
+
+# mailpit_http_port: "8025"
+# mailpit_https_port: "8026"
+# The Mailpit ports can be changed from the default 8025 and 8026
+
+# host_mailpit_port: "8025"
+# The mailpit port is not normally bound on the host at all, instead being routed
+# through ddev-router, but it can be bound directly to localhost if specified here.
+
+# webimage_extra_packages: ['php${DDEV_PHP_VERSION}-tidy', 'php${DDEV_PHP_VERSION}-yac']
+# Extra Debian packages that are needed in the webimage can be added here
+
+# dbimage_extra_packages: [netcat, telnet, sudo]
+# Extra Debian packages that are needed in the dbimage can be added here
+
+# use_dns_when_possible: true
+# If the host has internet access and the domain configured can
+# successfully be looked up, DNS will be used for hostname resolution
+# instead of editing /etc/hosts
+# Defaults to true
+
+# project_tld: ddev.site
+# The top-level domain used for project URLs
+# The default "ddev.site" allows DNS lookup via a wildcard
+
+# share_default_provider: ngrok
+# The default share provider to use for "ddev share"
+# Defaults to global configuration, usually "ngrok"
+# Can be "ngrok" or "cloudflared" or the name of a custom provider from .ddev/share-providers/
+
+# share_provider_args: --basic-auth username:pass1234
+# Provide extra flags to the share provider script
+# See https://docs.ddev.com/en/stable/users/configuration/config/#share_provider_args
+
+# disable_settings_management: false
+# If true, DDEV will not create CMS-specific settings files like
+# Drupal's settings.php/settings.ddev.php or TYPO3's additional.php
+# In this case the user must provide all such settings.
+
+# You can inject environment variables into the web container with:
+# web_environment:
+#     - SOMEENV=somevalue
+#     - SOMEOTHERENV=someothervalue
+
+# no_project_mount: false
+# (Experimental) If true, DDEV will not mount the project into the web container;
+# the user is responsible for mounting it manually or via a script.
+# This is to enable experimentation with alternate file mounting strategies.
+# For advanced users only!
+
+# bind_all_interfaces: false
+# If true, host ports will be bound on all network interfaces,
+# not the localhost interface only. This means that ports
+# will be available on the local network if the host firewall
+# allows it.
+
+# default_container_timeout: 120
+# The default time that DDEV waits for all containers to become ready can be increased from
+# the default 120. This helps in importing huge databases, for example.
+
+#web_extra_exposed_ports:
+#- name: nodejs
+#  container_port: 3000
+#  http_port: 2999
+#  https_port: 3000
+#- name: something
+#  container_port: 4000
+#  https_port: 4000
+#  http_port: 3999
+# Allows a set of extra ports to be exposed via ddev-router
+# Fill in all three fields even if you don’t intend to use the https_port!
+# If you don’t add https_port, then it defaults to 0 and ddev-router will fail to start.
+#
+# The port behavior on the ddev-webserver must be arranged separately, for example
+# using web_extra_daemons.
+# For example, with a web app on port 3000 inside the container, this config would
+# expose that web app on https://<project>.ddev.site:9999 and http://<project>.ddev.site:9998
+# web_extra_exposed_ports:
+#  - name: myapp
+#    container_port: 3000
+#    http_port: 9998
+#    https_port: 9999
+
+#web_extra_daemons:
+#- name: "http-1"
+#  command: "/var/www/html/node_modules/.bin/http-server -p 3000"
+#  directory: /var/www/html
+#- name: "http-2"
+#  command: "/var/www/html/node_modules/.bin/http-server /var/www/html/sub -p 3000"
+#  directory: /var/www/html
+
+# override_config: false
+# By default, config.*.yaml files are *merged* into the configuration
+# But this means that some things can't be overridden
+# For example, if you have 'use_dns_when_possible: true'' you can't override it with a merge
+# and you can't erase existing hooks or all environment variables.
+# However, with "override_config: true" in a particular config.*.yaml file,
+# 'use_dns_when_possible: false' can override the existing values, and
+# hooks:
+#   post-start: []
+# or
+# web_environment: []
+# or
+# additional_hostnames: []
+# can have their intended affect. 'override_config' affects only behavior of the
+# config.*.yaml file it exists in.
+
+# Many DDEV commands can be extended to run tasks before or after the
+# DDEV command is executed, for example "post-start", "post-import-db",
+# "pre-composer", "post-composer"
+# See https://docs.ddev.com/en/stable/users/extend/custom-commands/ for more
+# information on the commands that can be extended and the tasks you can define
+# for them. Example:
+#hooks:
+#  post-start:
+#    - exec: composer install -d /var/www/html

--- a/.ddev/docker-compose.typo3-setup.yaml
+++ b/.ddev/docker-compose.typo3-setup.yaml
@@ -1,0 +1,33 @@
+## #ddev-generated
+services:
+    web:
+        environment:
+            - EXTENSION_KEY=repeatable_form_elements
+            - EXTENSION_NAME=repeatable-form-elements
+            - PACKAGE_NAME=tritum/repeatable-form-elements
+            - TYPO3_VERSIONS=13 14
+            - SYMLINK_EXCLUSIONS=.* Documentation Documentation-GENERATED-temp var vendor public
+
+            # TYPO3 v11 and v12 config
+            - TYPO3_INSTALL_DB_DRIVER=mysqli
+            - TYPO3_INSTALL_DB_USER=root
+            - TYPO3_INSTALL_DB_PASSWORD=root
+            - TYPO3_INSTALL_DB_HOST=db
+            - TYPO3_INSTALL_DB_UNIX_SOCKET=
+            - TYPO3_INSTALL_DB_USE_EXISTING=0
+            - TYPO3_INSTALL_ADMIN_USER=admin
+            - TYPO3_INSTALL_ADMIN_PASSWORD=Password1!
+            - TYPO3_INSTALL_SITE_NAME=EXT:repeatable-form-elements Dev Environment
+            - TYPO3_INSTALL_SITE_SETUP_TYPE=site
+            - TYPO3_INSTALL_WEB_SERVER_CONFIG=apache
+
+            # TYPO3 v13 and v14 config
+            - TYPO3_DB_DRIVER=mysqli
+            - TYPO3_DB_USERNAME=root
+            - TYPO3_DB_PASSWORD=root
+            - TYPO3_DB_HOST=db
+            - TYPO3_SETUP_ADMIN_EMAIL=admin@example.com
+            - TYPO3_SETUP_ADMIN_USERNAME=admin
+            - TYPO3_SETUP_ADMIN_PASSWORD=Password1!
+            - TYPO3_PROJECT_NAME=EXT:repeatable-form-elements Dev Environment
+            - TYPO3_SERVER_TYPE=apache

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /public
 /vendor
 /composer.lock
+.Build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+## Unreleased
+
+### Breaking
+
+- Dropped TYPO3 v12 support. Minimum version is now TYPO3 v13.4 LTS.
+
+### Added
+
+- TYPO3 v14 compatibility
+- PSR-14 `AfterBuildingFinishedEvent` replaces the removed `afterBuildingFinished` SC_OPTIONS hook (Breaking #98239)
+- PSR-14 `AfterCurrentPageIsResolvedListener` replaces the removed `afterInitializeCurrentPage` SC_OPTIONS hook
+- PSR-14 `BeforeRenderableIsRenderedListener` replaces the removed `beforeRendering` SC_OPTIONS hook
+- DDEV multi-version test environment with pre-loaded form fixtures for v13 and v14
+
+### Changed
+
+- Removed `call_user_func` wrapper in `ext_localconf.php`
+- Removed deprecated `formEditorPartials` configuration for backend form editor (Deprecation #109306). Both v13 and v14 now use their default composite element rendering.
+- Typed `CopyService::$features` property as `Features` instead of `mixed`
+- Made `FormHooks` class `final`
+- Used explicit nullable types for PHP 8.4 compatibility
+- Updated `Services.yaml` to exclude Event classes from DI auto-registration
+
+### Migration
+
+Legacy SC_OPTIONS hook registrations are kept for v13 backward compatibility. The PSR-14 event listeners handle v14 automatically. No manual migration steps required.

--- a/Classes/Configuration/Extension.php
+++ b/Classes/Configuration/Extension.php
@@ -56,6 +56,9 @@ final class Extension
 
     public static function registerHooks(): void
     {
+        // These hooks are still supported in TYPO3 v13 and v14.
+        // When TYPO3 introduces PSR-14 replacements, migrate to event listeners
+        // registered in Configuration/Services.yaml.
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['afterInitializeCurrentPage'][1511196413] = FormHooks::class;
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['beforeRendering'][1511196413] = FormHooks::class;
     }

--- a/Classes/Configuration/Extension.php
+++ b/Classes/Configuration/Extension.php
@@ -41,8 +41,14 @@ final class Extension
 
     public static function addTypoScriptSetup(): void
     {
-        // @todo: maybe move this to 'EXT:repeatable_form_elements/ext_typoscript_setup.typoscript'
         ExtensionManagementUtility::addTypoScriptSetup(trim('
+            plugin.tx_form {
+                settings {
+                    yamlConfigurations {
+                        1511193633 = EXT:repeatable_form_elements/Configuration/Yaml/FormSetup.yaml
+                    }
+                }
+            }
             module.tx_form {
                 settings {
                     yamlConfigurations {
@@ -56,9 +62,9 @@ final class Extension
 
     public static function registerHooks(): void
     {
-        // These hooks are still supported in TYPO3 v13 and v14.
-        // When TYPO3 introduces PSR-14 replacements, migrate to event listeners
-        // registered in Configuration/Services.yaml.
+        // v13: these SC_OPTIONS hooks are the active mechanism.
+        // v14: these hooks were removed (Breaking #107566, #107569).
+        //      The PSR-14 event listeners in Configuration/Services.yaml take over.
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['afterInitializeCurrentPage'][1511196413] = FormHooks::class;
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['beforeRendering'][1511196413] = FormHooks::class;
     }

--- a/Classes/Event/AfterBuildingFinishedEvent.php
+++ b/Classes/Event/AfterBuildingFinishedEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TRITUM\RepeatableFormElements\Event;
+
+use TYPO3\CMS\Form\Domain\Model\Renderable\RenderableInterface;
+
+/**
+ * Dispatched after a form renderable has been built/copied by the repeatable container logic.
+ *
+ * This event replaces the former SC_OPTIONS hook
+ * $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['afterBuildingFinished']
+ * which was removed in TYPO3 v14 (Breaking #98239).
+ */
+final class AfterBuildingFinishedEvent
+{
+    public function __construct(
+        public readonly RenderableInterface $renderable,
+    ) {}
+}

--- a/Classes/EventListener/AfterCurrentPageIsResolvedListener.php
+++ b/Classes/EventListener/AfterCurrentPageIsResolvedListener.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TRITUM\RepeatableFormElements\EventListener;
+
+use TRITUM\RepeatableFormElements\Hooks\FormHooks;
+use TYPO3\CMS\Form\Event\AfterCurrentPageIsResolvedEvent;
+
+/**
+ * PSR-14 replacement for the afterInitializeCurrentPage SC_OPTIONS hook.
+ * This event listener is used in TYPO3 v14+ where the hook was removed.
+ */
+final class AfterCurrentPageIsResolvedListener
+{
+    public function __construct(
+        private readonly FormHooks $formHooks,
+    ) {}
+
+    public function __invoke(AfterCurrentPageIsResolvedEvent $event): void
+    {
+        $event->currentPage = $this->formHooks->afterInitializeCurrentPage(
+            $event->formRuntime,
+            $event->currentPage,
+            $event->lastDisplayedPage,
+            $event->request->getArguments(),
+        );
+    }
+}

--- a/Classes/EventListener/BeforeRenderableIsRenderedListener.php
+++ b/Classes/EventListener/BeforeRenderableIsRenderedListener.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TRITUM\RepeatableFormElements\EventListener;
+
+use TRITUM\RepeatableFormElements\Hooks\FormHooks;
+use TYPO3\CMS\Form\Event\BeforeRenderableIsRenderedEvent;
+
+/**
+ * PSR-14 replacement for the beforeRendering SC_OPTIONS hook.
+ * This event listener is used in TYPO3 v14+ where the hook was removed.
+ */
+final class BeforeRenderableIsRenderedListener
+{
+    public function __construct(
+        private readonly FormHooks $formHooks,
+    ) {}
+
+    public function __invoke(BeforeRenderableIsRenderedEvent $event): void
+    {
+        $this->formHooks->beforeRendering($event->formRuntime, $event->renderable);
+    }
+}

--- a/Classes/Hooks/FormHooks.php
+++ b/Classes/Hooks/FormHooks.php
@@ -24,7 +24,7 @@ use TYPO3\CMS\Form\Domain\Model\Renderable\RenderableInterface;
 use TYPO3\CMS\Form\Domain\Model\Renderable\RootRenderableInterface;
 use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
 
-class FormHooks
+final class FormHooks
 {
     /**
      * @param FormRuntime $formRuntime
@@ -37,8 +37,8 @@ class FormHooks
      */
     public function afterInitializeCurrentPage(
         FormRuntime $formRuntime,
-        CompositeRenderableInterface $currentPage = null,
-        CompositeRenderableInterface $lastPage = null,
+        ?CompositeRenderableInterface $currentPage = null,
+        ?CompositeRenderableInterface $lastPage = null,
         array $rawRequestArguments = [],
     ): ?CompositeRenderableInterface {
         foreach ($formRuntime->getPages() as $page) {
@@ -158,8 +158,8 @@ class FormHooks
      */
     protected function userWentBackToPreviousStep(
         FormRuntime $formRuntime,
-        CompositeRenderableInterface $currentPage = null,
-        CompositeRenderableInterface $lastPage = null,
+        ?CompositeRenderableInterface $currentPage = null,
+        ?CompositeRenderableInterface $lastPage = null,
     ): bool {
         return $currentPage !== null
                 && $lastPage !== null

--- a/Classes/Hooks/FormHooks.php
+++ b/Classes/Hooks/FormHooks.php
@@ -10,6 +10,8 @@ namespace TRITUM\RepeatableFormElements\Hooks;
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TRITUM\RepeatableFormElements\Event\AfterBuildingFinishedEvent;
 use TRITUM\RepeatableFormElements\FormElements\RepeatableContainerInterface;
 use TRITUM\RepeatableFormElements\Service\CopyService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -125,12 +127,17 @@ class FormHooks
                 $renderable->addValidator($validator);
             }
 
+            // Legacy hook (v13 compat, no-op in v14)
             foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['afterBuildingFinished'] ?? [] as $className) {
                 $hookObj = GeneralUtility::makeInstance($className);
                 if (method_exists($hookObj, 'afterBuildingFinished')) {
                     $hookObj->afterBuildingFinished($renderable);
                 }
             }
+            // PSR-14 event (v13 + v14)
+            GeneralUtility::makeInstance(EventDispatcherInterface::class)->dispatch(
+                new AfterBuildingFinishedEvent($renderable)
+            );
         }
 
         if ($renderable instanceof CompositeRenderableInterface) {

--- a/Classes/Service/CopyService.php
+++ b/Classes/Service/CopyService.php
@@ -12,6 +12,7 @@ namespace TRITUM\RepeatableFormElements\Service;
  */
 
 use Psr\EventDispatcher\EventDispatcherInterface;
+use TRITUM\RepeatableFormElements\Event\AfterBuildingFinishedEvent;
 use TRITUM\RepeatableFormElements\Event\CopyVariantEvent;
 use TRITUM\RepeatableFormElements\FormElements\RepeatableContainerInterface;
 use TYPO3\CMS\Core\Configuration\Features;
@@ -23,6 +24,7 @@ use TYPO3\CMS\Extbase\Validation\Validator\ValidatorInterface;
 use TYPO3\CMS\Form\Domain\Model\FormDefinition;
 use TYPO3\CMS\Form\Domain\Model\FormElements\FormElementInterface;
 use TYPO3\CMS\Form\Domain\Model\Renderable\CompositeRenderableInterface;
+use TYPO3\CMS\Form\Domain\Model\Renderable\RenderableInterface;
 use TYPO3\CMS\Form\Domain\Model\Renderable\RenderableVariant;
 use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
 use TYPO3\CMS\Form\Domain\Runtime\FormState;
@@ -36,7 +38,8 @@ class CopyService
     protected FormDefinition $formDefinition;
     protected array $repeatableContainersByOriginalIdentifier = [];
     protected array $typeDefinitions = [];
-    protected mixed $features;
+    protected Features $features;
+    protected EventDispatcherInterface $eventDispatcher;
 
     /**
      * @param FormRuntime $formRuntime
@@ -48,6 +51,7 @@ class CopyService
         $this->formDefinition = $formRuntime->getFormDefinition();
         $this->typeDefinitions = $this->formDefinition->getTypeDefinitions();
         $this->features = GeneralUtility::makeInstance(Features::class);
+        $this->eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
     }
 
     /**
@@ -185,12 +189,7 @@ class CopyService
         $parentRenderableForNewContainer->addElement($newContainer);
         $parentRenderableForNewContainer->moveElementAfter($newContainer, $moveAfterContainer);
 
-        foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['afterBuildingFinished'] ?? [] as $className) {
-            $hookObj = GeneralUtility::makeInstance($className);
-            if (method_exists($hookObj, 'afterBuildingFinished')) {
-                $hookObj->afterBuildingFinished($newContainer);
-            }
-        }
+        $this->dispatchAfterBuildingFinished($newContainer);
 
         foreach ($copyFromContainer->getElements() as $originalFormElement) {
             $this->createNestedElements($originalFormElement, $newContainer, $copyFromContainer->getIdentifier(), $newIdentifier);
@@ -252,12 +251,7 @@ class CopyService
         $this->copyProcessingRule($originalFormElement->getIdentifier(), $newIdentifier);
         $this->copyVariants($originalFormElement, $newFormElement, $newIdentifier);
 
-        foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['afterBuildingFinished'] ?? [] as $className) {
-            $hookObj = GeneralUtility::makeInstance($className);
-            if (method_exists($hookObj, 'afterBuildingFinished')) {
-                $hookObj->afterBuildingFinished($newFormElement);
-            }
-        }
+        $this->dispatchAfterBuildingFinished($newFormElement);
 
         if ($originalFormElement instanceof CompositeRenderableInterface) {
             foreach ($originalFormElement->getElements() as $originalChildFormElement) {
@@ -390,9 +384,8 @@ class CopyService
                 $options['condition'] = $propCondition->getValue($originalVariant);
                 $options['identifier'] = $originalIdentifier;
 
-                $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
                 /** @var CopyVariantEvent $event */
-                $event = $eventDispatcher->dispatch(
+                $event = $this->eventDispatcher->dispatch(
                     new CopyVariantEvent($options, $originalFormElement, $newFormElement, $newIdentifier),
                 );
 
@@ -407,4 +400,20 @@ class CopyService
         }
     }
 
+    /**
+     * Dispatch the afterBuildingFinished event/hook for a renderable.
+     * In v13: dispatches both the legacy SC_OPTIONS hook and the PSR-14 event.
+     * In v14+: the SC_OPTIONS hook no longer exists, only the PSR-14 event fires.
+     */
+    protected function dispatchAfterBuildingFinished(RenderableInterface $renderable): void
+    {
+        foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['afterBuildingFinished'] ?? [] as $className) {
+            $hookObj = GeneralUtility::makeInstance($className);
+            if (method_exists($hookObj, 'afterBuildingFinished')) {
+                $hookObj->afterBuildingFinished($renderable);
+            }
+        }
+
+        $this->eventDispatcher->dispatch(new AfterBuildingFinishedEvent($renderable));
+    }
 }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -6,6 +6,9 @@ services:
 
   TRITUM\RepeatableFormElements\:
     resource: '../Classes/*'
+    exclude:
+      - '../Classes/Domain/Model/*'
+      - '../Classes/Event/*'
 
   TRITUM\RepeatableFormElements\EventListener\AdaptVariantConditionEventListener:
     tags:

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -14,3 +14,13 @@ services:
     tags:
       - name: event.listener
         identifier: 'repeatableFormElements/copyVariants/adaptCondition'
+
+  TRITUM\RepeatableFormElements\EventListener\AfterCurrentPageIsResolvedListener:
+    tags:
+      - name: event.listener
+        identifier: 'repeatableFormElements/afterCurrentPageIsResolved'
+
+  TRITUM\RepeatableFormElements\EventListener\BeforeRenderableIsRenderedListener:
+    tags:
+      - name: event.listener
+        identifier: 'repeatableFormElements/beforeRenderableIsRendered'

--- a/Configuration/Yaml/FormSetupBackend.yaml
+++ b/Configuration/Yaml/FormSetupBackend.yaml
@@ -58,5 +58,5 @@ prototypes:
       dynamicJavaScriptModules:
         additionalViewModelModules:
           1595333290: '@tritum/repeatable-form-elements/backend/form-editor/view-model.js'
-      formEditorPartials:
-        FormElement-RepeatableContainer: 'Stage/Fieldset'
+      # formEditorPartials removed: v14 uses web components for stage rendering (Deprecation #109306)
+      # Omitting formEditorPartials lets both v13 and v14 use their default composite element rendering.

--- a/Tests/Acceptance/Fixtures/data.sql
+++ b/Tests/Acceptance/Fixtures/data.sql
@@ -1,0 +1,19 @@
+-- Pages
+INSERT INTO `pages` (`uid`, `pid`, `title`, `slug`, `doktype`, `is_siteroot`, `sorting`, `hidden`)
+VALUES
+  (2, 1, 'Simple Repeatable Form', '/simple-form', 1, 0, 256, 0),
+  (3, 1, 'Nested Multi-Step Form', '/nested-form', 1, 0, 512, 0)
+ON DUPLICATE KEY UPDATE `title`=VALUES(`title`), `slug`=VALUES(`slug`);
+
+-- Remove default content from root page (v14 setup creates a welcome element)
+DELETE FROM `tt_content` WHERE `pid` = 1;
+
+-- Content elements: Form plugins (use high UIDs to avoid conflicts)
+INSERT INTO `tt_content` (`uid`, `pid`, `CType`, `header`, `sorting`, `colPos`, `pi_flexform`)
+VALUES
+  (100, 2, 'form_formframework', 'Simple Repeatable Form', 256, 0, '<?xml version="1.0" encoding="utf-8" standalone="yes" ?>\n<T3FlexForms>\n    <data>\n        <sheet index="sDEF">\n            <language index="lDEF">\n                <field index="settings.persistenceIdentifier">\n                    <value index="vDEF">1:/form_definitions/repeatable-simple.form.yaml</value>\n                </field>\n            </language>\n        </sheet>\n    </data>\n</T3FlexForms>'),
+  (101, 3, 'form_formframework', 'Nested Multi-Step Form', 256, 0, '<?xml version="1.0" encoding="utf-8" standalone="yes" ?>\n<T3FlexForms>\n    <data>\n        <sheet index="sDEF">\n            <language index="lDEF">\n                <field index="settings.persistenceIdentifier">\n                    <value index="vDEF">1:/form_definitions/repeatable-nested.form.yaml</value>\n                </field>\n            </language>\n        </sheet>\n    </data>\n</T3FlexForms>')
+ON DUPLICATE KEY UPDATE `pid`=VALUES(`pid`), `CType`=VALUES(`CType`), `header`=VALUES(`header`), `pi_flexform`=VALUES(`pi_flexform`);
+
+-- Update root page title
+UPDATE `pages` SET `title` = 'Repeatable Form Elements Test' WHERE `uid` = 1;

--- a/Tests/Acceptance/Fixtures/form_definitions/repeatable-nested.form.yaml
+++ b/Tests/Acceptance/Fixtures/form_definitions/repeatable-nested.form.yaml
@@ -1,0 +1,82 @@
+renderingOptions:
+  submitButtonLabel: Absenden
+type: Form
+identifier: repeatable-nested
+label: 'Repeatable Container - Nested & Multi-Step'
+prototypeName: standard
+finishers:
+  -
+    identifier: Confirmation
+    options:
+      message: 'Vielen Dank! Alle Daten wurden korrekt uebermittelt.'
+renderables:
+  -
+    type: Page
+    identifier: page-1
+    label: 'Schritt 1: Teilnehmer'
+    renderingOptions:
+      previousButtonLabel: Zurueck
+      nextButtonLabel: Weiter
+    renderables:
+      -
+        type: Text
+        identifier: event-name
+        label: Veranstaltung
+        validators:
+          -
+            identifier: NotEmpty
+      -
+        type: RepeatableContainer
+        identifier: participants
+        label: Teilnehmer
+        properties:
+          minimumCopies: 1
+          maximumCopies: 10
+          showRemoveButton: true
+          copyButtonLabel: 'Teilnehmer hinzufuegen'
+          removeButtonLabel: 'Teilnehmer entfernen'
+        renderables:
+          -
+            type: Text
+            identifier: name
+            label: Name
+            validators:
+              -
+                identifier: NotEmpty
+          -
+            type: Email
+            identifier: email
+            label: E-Mail
+          -
+            type: SingleSelect
+            identifier: ticket-type
+            label: Ticket-Typ
+            properties:
+              options:
+                '': 'Bitte waehlen'
+                standard: Standard
+                vip: VIP
+                student: Student
+          -
+            type: Checkbox
+            identifier: catering
+            label: 'Catering gewuenscht'
+  -
+    type: Page
+    identifier: page-2
+    label: 'Schritt 2: Zusatzinformationen'
+    renderingOptions:
+      previousButtonLabel: Zurueck
+      nextButtonLabel: Weiter
+    renderables:
+      -
+        type: Textarea
+        identifier: notes
+        label: Anmerkungen
+        properties:
+          fluidAdditionalAttributes:
+            rows: '4'
+  -
+    type: SummaryPage
+    identifier: summary
+    label: Zusammenfassung

--- a/Tests/Acceptance/Fixtures/form_definitions/repeatable-simple.form.yaml
+++ b/Tests/Acceptance/Fixtures/form_definitions/repeatable-simple.form.yaml
@@ -1,0 +1,58 @@
+renderingOptions:
+  submitButtonLabel: Absenden
+type: Form
+identifier: repeatable-simple
+label: 'Repeatable Container - Simple Test'
+prototypeName: standard
+finishers:
+  -
+    identifier: Confirmation
+    options:
+      message: 'Vielen Dank! Das Formular wurde erfolgreich abgesendet.'
+renderables:
+  -
+    type: Page
+    identifier: page-1
+    label: 'Kontaktdaten'
+    renderables:
+      -
+        type: Text
+        identifier: company
+        label: Firma
+        properties:
+          fluidAdditionalAttributes:
+            placeholder: 'Firmenname'
+      -
+        type: RepeatableContainer
+        identifier: persons
+        label: Personen
+        properties:
+          minimumCopies: 0
+          maximumCopies: 5
+          showRemoveButton: true
+          copyButtonLabel: 'Weitere Person hinzufuegen'
+          removeButtonLabel: 'Person entfernen'
+        renderables:
+          -
+            type: Text
+            identifier: firstname
+            label: Vorname
+            validators:
+              -
+                identifier: NotEmpty
+          -
+            type: Text
+            identifier: lastname
+            label: Nachname
+            validators:
+              -
+                identifier: NotEmpty
+          -
+            type: Email
+            identifier: email
+            label: E-Mail
+            validators:
+              -
+                identifier: NotEmpty
+              -
+                identifier: EmailAddress

--- a/Tests/Acceptance/Fixtures/packages/sitepackage/Configuration/Services.yaml
+++ b/Tests/Acceptance/Fixtures/packages/sitepackage/Configuration/Services.yaml
@@ -1,0 +1,6 @@
+#ddev-generated
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false

--- a/Tests/Acceptance/Fixtures/packages/sitepackage/Configuration/Sets/Sitepackage/config.yaml
+++ b/Tests/Acceptance/Fixtures/packages/sitepackage/Configuration/Sets/Sitepackage/config.yaml
@@ -1,0 +1,6 @@
+name: test/sitepackage
+label: Test Sitepackage
+dependencies:
+  - typo3/fluid-styled-content
+  - typo3/form
+  - tritum/repeatable-form-elements

--- a/Tests/Acceptance/Fixtures/packages/sitepackage/Configuration/Sets/Sitepackage/setup.typoscript
+++ b/Tests/Acceptance/Fixtures/packages/sitepackage/Configuration/Sets/Sitepackage/setup.typoscript
@@ -1,0 +1,12 @@
+page = PAGE
+page {
+  typeNum = 0
+  includeCSSLibs.bootstrap = https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css
+  includeCSSLibs.bootstrap.external = 1
+  10 = FLUIDTEMPLATE
+  10 {
+    templateName = Default
+    templateRootPaths.10 = EXT:sitepackage/Resources/Private/Templates/Page/
+    layoutRootPaths.10 = EXT:sitepackage/Resources/Private/Layouts/
+  }
+}

--- a/Tests/Acceptance/Fixtures/packages/sitepackage/README.md
+++ b/Tests/Acceptance/Fixtures/packages/sitepackage/README.md
@@ -1,0 +1,6 @@
+#ddev-generated
+# Sitepackage
+
+This is a demo sitepackage for testing purposes.
+
+Adjust them to your needs to test features of the main extension.

--- a/Tests/Acceptance/Fixtures/packages/sitepackage/Resources/Private/Layouts/Default.html
+++ b/Tests/Acceptance/Fixtures/packages/sitepackage/Resources/Private/Layouts/Default.html
@@ -1,0 +1,6 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+<div class="container py-4">
+    <h1>{data.title}</h1>
+    <f:render section="Main" />
+</div>
+</html>

--- a/Tests/Acceptance/Fixtures/packages/sitepackage/Resources/Private/Templates/Page/Default.html
+++ b/Tests/Acceptance/Fixtures/packages/sitepackage/Resources/Private/Templates/Page/Default.html
@@ -1,0 +1,6 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+<f:layout name="Default" />
+<f:section name="Main">
+    <f:cObject typoscriptObjectPath="styles.content.get" />
+</f:section>
+</html>

--- a/Tests/Acceptance/Fixtures/packages/sitepackage/composer.json
+++ b/Tests/Acceptance/Fixtures/packages/sitepackage/composer.json
@@ -1,0 +1,23 @@
+{
+  "name": "test/sitepackage",
+  "description": "Sitepackage for repeatable_form_elements testing",
+  "license": "GPL-2.0-or-later",
+  "type": "typo3-cms-extension",
+  "require": {
+    "typo3/cms-core": "^13.4 || ^14.0",
+    "typo3/cms-fluid-styled-content": "^13.4 || ^14.0",
+    "typo3/cms-form": "^13.4 || ^14.0",
+    "tritum/repeatable-form-elements": "*"
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "sitepackage"
+    }
+  },
+  "version": "1.0.0",
+  "autoload": {
+    "psr-4": {
+      "Test\\Sitepackage\\": "Classes/"
+    }
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
         }
     ],
     "require": {
-        "typo3/cms-core": "^12.4 || ^13.4",
-        "typo3/cms-extbase": "^12.4 || ^13.4",
-        "typo3/cms-form": "^12.4 || ^13.4"
+        "typo3/cms-core": "^13.4 || ^14.0",
+        "typo3/cms-extbase": "^13.4 || ^14.0",
+        "typo3/cms-form": "^13.4 || ^14.0"
     },
     "autoload": {
         "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,10 +7,10 @@ $EM_CONF['repeatable_form_elements'] = [
     'state' => 'stable',
     'author' => 'Ralf Zimmermann, Elias Häußler, Christian Seyfferth',
     'author_email' => 'r.zimmermann@dreistrom.land, elias@haeussler.dev, c.seyfferth@dreistrom.land',
-    'version' => '5.0.0',
+    'version' => '6.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.4.0-13.4.99',
+            'typo3' => '13.4.0-14.99.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -4,9 +4,7 @@ use TRITUM\RepeatableFormElements\Configuration\Extension;
 
 defined('TYPO3') or die();
 
-call_user_func(function () {
-    Extension::addTypoScriptSetup();
-    Extension::registerHooks();
+Extension::addTypoScriptSetup();
+Extension::registerHooks();
 
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['repeatableFormElements.copyVariants'] ??= true;
-});
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['repeatableFormElements.copyVariants'] ??= true;


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                            
  This PR adds full TYPO3 v14 compatibility while maintaining v13 support. TYPO3 v12 is dropped.                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                            
  ### Breaking changes                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                            
  - Minimum TYPO3 version is now v13.4 LTS                                                                             
  - Version constraints updated to `^13.4 || ^14.0`                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                            
  ### TYPO3 v14 hook removals addressed
                                                                                                                                                                                                                                                                                            
  TYPO3 v14 removed several SC_OPTIONS hooks that this extension relies on. This PR introduces PSR-14 event listeners as replacements:
                                         
  | Removed Hook | PSR-14 Replacement |                                                                                                                                                                                                                                                     
  |---|---|
  | `afterBuildingFinished` (Breaking #98239) | `AfterBuildingFinishedEvent` — new event dispatched by CopyService and FormHooks |                                                                                                                                                          
  | `afterInitializeCurrentPage` | `AfterCurrentPageIsResolvedListener` — listens to core's `AfterCurrentPageIsResolvedEvent` |
  | `beforeRendering` | `BeforeRenderableIsRenderedListener` — listens to core's `BeforeRenderableIsRenderedEvent` |                                                                                                                                                                        
                                                                                                                                                                                                                                                                                            
  Legacy hook registrations are kept for v13 backward compatibility. On v13, only the hooks fire (PSR-14 events don't exist yet). On v14, only the PSR-14 listeners fire (hooks are silently ignored).                                                                                      
                                                                                                                                                                                                                                                                                            
  ### Backend form editor fix                                                                                                                                                                                                                                                               
                                         
  Removed the deprecated `formEditorPartials` configuration (Deprecation #109306). TYPO3 v14.2 replaced Fluid-based stage partials with web components. Omitting `formEditorPartials` lets both v13 and v14 use their default composite element rendering, fixing the visual nesting of     
  child elements in the backend form editor.                                                                           
                                                                                                                                                                                                                                                                                            
  ### Additional changes                                                                                               
                                         
  - Removed unnecessary `call_user_func` wrapper in `ext_localconf.php`
  - Made `FormHooks` class `final`
  - Typed `CopyService::$features` as `Features` instead of `mixed`
  - Used explicit nullable types for PHP 8.4 compatibility                                                                                                                                                                                                                                  
  - Updated `Services.yaml` to exclude Event value objects from DI
  - Added DDEV multi-version test environment with form fixtures for v13/v14                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                            
  ### Tested on                          
                                                                                                                                                                                                                                                                                            
  - [x] TYPO3 v13.4.28 — Frontend rendering, copy/remove, multi-step forms, backend form editor                        
  - [x] TYPO3 v14.2.0 — Frontend rendering, copy/remove, multi-step forms, backend form editor